### PR TITLE
location-scale Student t distribution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets=c('rd', 'collate', 'namespace'))
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,11 @@ Authors@R:
       person(given = "Earo",
              family = "Wang",
              role = c("ctb"),
-             comment = c(ORCID = "0000-0001-6448-5260")))
+             comment = c(ORCID = "0000-0001-6448-5260")),
+      person(given = "Matthew",
+             family = "Kay",
+             role = c("ctb"),
+             comment = c(ORCID = "0000-0001-9446-0419")))
 Description: Vectorised distribution objects with tools for manipulating, 
     visualising, and using probability distributions. Designed to allow model
     prediction outputs to return distributions rather than their parameters, 

--- a/R/dist_student_t.R
+++ b/R/dist_student_t.R
@@ -22,7 +22,7 @@ dist_student_t <- function(df, mu = 0, sigma = 1, ncp = NULL){
   mu <- vec_cast(mu, double())
   sigma <- vec_cast(sigma, double())
   if(any(sigma[!is.na(sigma)] <= 0)){
-    abort("The scale parameter of a Student t distribution must be strictly positive.")
+    abort("The scale (sigma) parameter of a Student t distribution must be strictly positive.")
   }
   new_dist(df = df, mu = mu, sigma = sigma, ncp = ncp, class = "dist_student_t")
 }

--- a/R/dist_student_t.R
+++ b/R/dist_student_t.R
@@ -1,13 +1,16 @@
-#' The (non-central) Student t Distribution
+#' The (non-central) location-scale Student t Distribution
 #'
 #' \lifecycle{stable}
 #'
 #' @inheritParams stats::dt
+#' @param mu The location parameter of the distribution.
+#'   If `ncp == 0` (or `NULL`), this is the median.
+#' @param sigma The scale parameter of the distribution.
 #'
 #' @seealso [stats::TDist]
 #'
 #' @examples
-#' dist_student_t(df = c(1,2,5))
+#' dist_student_t(df = c(1,2,5), mu = c(0,1,2), sigma = c(1,2,3))
 #'
 #' @name dist_student_t
 #' @export
@@ -43,29 +46,30 @@ format.dist_student_t <- function(x, digits = 2, ...){
 #' @export
 density.dist_student_t <- function(x, at, ...){
   ncp <- x[["ncp"]] %||% missing_arg()
+  sigma <- x[["sigma"]]
 
-  stats::dt(at, x[["df"]], ncp)
+  stats::dt((at - x[["mu"]])/sigma, x[["df"]], ncp) / sigma
 }
 
 #' @export
 quantile.dist_student_t <- function(x, p, ...){
   ncp <- x[["ncp"]] %||% missing_arg()
 
-  stats::qt(p, x[["df"]], ncp)
+  stats::qt(p, x[["df"]], ncp) * x[["sigma"]] + x[["mu"]]
 }
 
 #' @export
 cdf.dist_student_t <- function(x, q, ...){
   ncp <- x[["ncp"]] %||% missing_arg()
 
-  stats::pt(q, x[["df"]], ncp)
+  stats::pt((q - x[["mu"]])/x[["sigma"]], x[["df"]], ncp)
 }
 
 #' @export
 generate.dist_student_t <- function(x, times, ...){
   ncp <- x[["ncp"]] %||% missing_arg()
 
-  stats::rt(times, x[["df"]], ncp)
+  stats::rt(times, x[["df"]], ncp) * x[["sigma"]] + x[["mu"]]
 }
 
 #' @export
@@ -73,20 +77,21 @@ mean.dist_student_t <- function(x, ...){
   df <- x[["df"]]
   if(df <= 1) return(NA_real_)
   if(is.null(x[["ncp"]])){
-    0
+    x[["mu"]]
   } else {
-    x[["ncp"]] * sqrt(df/2) * (gamma((df-1)/2)/gamma(df/2))
+    x[["mu"]] + x[["ncp"]] * sqrt(df/2) * (gamma((df-1)/2)/gamma(df/2)) * x[["sigma"]]
   }
 }
 
 #' @export
 variance.dist_student_t <- function(x, ...){
   df <- x[["df"]]
+  ncp <- x[["ncp"]]
   if(df <= 1) return(NA_real_)
   if(df <= 2) return(Inf)
-  if(is.null(x[["ncp"]])){
-    df / (df - 2)
+  if(is.null(ncp)){
+    df / (df - 2) * x[["sigma"]]^2
   } else {
-    (df*(1+x[["ncp"]]^2))/(df-2) - mean(x)^2
+    ((df*(1+ncp^2))/(df-2) - (ncp * sqrt(df/2) * (gamma((df-1)/2)/gamma(df/2)))^2) * x[["sigma"]]^2
   }
 }

--- a/R/dist_student_t.R
+++ b/R/dist_student_t.R
@@ -11,16 +11,17 @@
 #'
 #' @name dist_student_t
 #' @export
-dist_student_t <- function(df, ncp = NULL){
+dist_student_t <- function(df, mu = 0, sigma = 1, ncp = NULL){
   df <- vec_cast(df, if(any(is.infinite(df))) numeric() else integer())
   if(any(df <= 0)){
     abort("The degrees of freedom parameter of a Student t distribution must be strictly positive.")
   }
-  if(is.null(ncp)){
-    new_dist(df = df, class = "dist_student_t")
-  } else {
-    new_dist(df = df, ncp = ncp, class = "dist_student_t")
+  mu <- vec_cast(mu, double())
+  sigma <- vec_cast(sigma, double())
+  if(any(sigma[!is.na(sigma)] <= 0)){
+    abort("The scale parameter of a Student t distribution must be strictly positive.")
   }
+  new_dist(df = df, mu = mu, sigma = sigma, ncp = ncp, class = "dist_student_t")
 }
 
 #' @export
@@ -30,46 +31,41 @@ print.dist_student_t <- function(x, ...){
 
 #' @export
 format.dist_student_t <- function(x, digits = 2, ...){
-  sprintf(
-    "t(%s)",
-    format(x[["df"]], digits = digits, ...)
+  out <- sprintf(
+    "t(%s, %s, %s%s)",
+    format(x[["df"]], digits = digits, ...),
+    format(x[["mu"]], digits = digits, ...),
+    format(x[["sigma"]], digits = digits, ...),
+    if(is.null(x[["ncp"]])) "" else paste(",", format(x[["ncp"]], digits = digits, ...))
   )
 }
 
 #' @export
 density.dist_student_t <- function(x, at, ...){
-  if(is.null(x[["ncp"]])){
-    stats::dt(at, x[["df"]])
-  } else {
-    stats::dt(at, x[["df"]], x[["ncp"]])
-  }
+  ncp <- x[["ncp"]] %||% missing_arg()
+
+  stats::dt(at, x[["df"]], ncp)
 }
 
 #' @export
 quantile.dist_student_t <- function(x, p, ...){
-  if(is.null(x[["ncp"]])){
-    stats::qt(p, x[["df"]])
-  } else {
-    stats::qt(p, x[["df"]], x[["ncp"]])
-  }
+  ncp <- x[["ncp"]] %||% missing_arg()
+
+  stats::qt(p, x[["df"]], ncp)
 }
 
 #' @export
 cdf.dist_student_t <- function(x, q, ...){
-  if(is.null(x[["ncp"]])){
-    stats::pt(q, x[["df"]])
-  } else {
-    stats::pt(q, x[["df"]], x[["ncp"]])
-  }
+  ncp <- x[["ncp"]] %||% missing_arg()
+
+  stats::pt(q, x[["df"]], ncp)
 }
 
 #' @export
 generate.dist_student_t <- function(x, times, ...){
-  if(is.null(x[["ncp"]])){
-    stats::rt(times, x[["df"]])
-  } else {
-    stats::rt(times, x[["df"]], x[["ncp"]])
-  }
+  ncp <- x[["ncp"]] %||% missing_arg()
+
+  stats::rt(times, x[["df"]], ncp)
 }
 
 #' @export

--- a/man/dist_f.Rd
+++ b/man/dist_f.Rd
@@ -21,5 +21,5 @@ dist_f(df1 = c(1,2,5,10,100), df2 = c(1,1,2,1,100))
 
 }
 \seealso{
-\link[stats:FDist]{stats::FDist}
+\link[stats:Fdist]{stats::FDist}
 }

--- a/man/dist_student_t.Rd
+++ b/man/dist_student_t.Rd
@@ -2,13 +2,18 @@
 % Please edit documentation in R/dist_student_t.R
 \name{dist_student_t}
 \alias{dist_student_t}
-\title{The (non-central) Student t Distribution}
+\title{The (non-central) location-scale Student t Distribution}
 \usage{
-dist_student_t(df, ncp = NULL)
+dist_student_t(df, mu = 0, sigma = 1, ncp = NULL)
 }
 \arguments{
 \item{df}{degrees of freedom (\eqn{> 0}, maybe non-integer).  \code{df
       = Inf} is allowed.}
+
+\item{mu}{The location parameter of the distribution.
+If \code{ncp == 0} (or \code{NULL}), this is the median.}
+
+\item{sigma}{The scale parameter of the distribution.}
 
 \item{ncp}{non-centrality parameter \eqn{\delta}{delta};
     currently except for \code{rt()}, only for \code{abs(ncp) <= 37.62}.
@@ -18,7 +23,7 @@ dist_student_t(df, ncp = NULL)
 \lifecycle{stable}
 }
 \examples{
-dist_student_t(df = c(1,2,5))
+dist_student_t(df = c(1,2,5), mu = c(0,1,2), sigma = c(1,2,3))
 
 }
 \seealso{

--- a/man/distributional-package.Rd
+++ b/man/distributional-package.Rd
@@ -29,6 +29,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Earo Wang (\href{https://orcid.org/0000-0001-6448-5260}{ORCID}) [contributor]
+  \item Matthew Kay (\href{https://orcid.org/0000-0001-9446-0419}{ORCID}) [contributor]
 }
 
 }

--- a/man/scale_hilo_continuous.Rd
+++ b/man/scale_hilo_continuous.Rd
@@ -33,7 +33,7 @@ omitted.}
 \link[scales:trans_new]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
-as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scales::extended_breaks()}})
+as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}})
 }}
 
 \item{minor_breaks}{One of:
@@ -83,10 +83,10 @@ expand the scale by 5\% on each side for continuous variables, and by
 \itemize{
 \item Function that handles limits outside of the scale limits
 (out of bounds).
-\item The default (\code{\link[scales:censor]{scales::censor()}}) replaces out of
+\item The default (\code{\link[scales:oob]{scales::censor()}}) replaces out of
 bounds values with \code{NA}.
-\item \code{\link[scales:squish]{scales::squish()}} for squishing out of bounds values into range.
-\item \code{\link[scales:squish_infinite]{scales::squish_infinite()}} for squishing infinite values into range.
+\item \code{\link[scales:oob]{scales::squish()}} for squishing out of bounds values into range.
+\item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
 }}
 
 \item{na.value}{Missing values will be replaced with this value.}

--- a/man/scale_level.Rd
+++ b/man/scale_level.Rd
@@ -27,7 +27,7 @@ omitted.}
 \link[scales:trans_new]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
-as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scales::extended_breaks()}})
+as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}})
 }}
     \item{\code{minor_breaks}}{One of:
 \itemize{
@@ -63,17 +63,17 @@ If the purpose is to zoom, use the limit argument in the coordinate system
 }}
     \item{\code{rescaler}}{A function used to scale the input values to the
 range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
-diverging and n colour gradients (i.e., \code{\link[ggplot2:scale_colour_gradient2]{scale_colour_gradient2()}},
-\code{\link[ggplot2:scale_colour_gradientn]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
+diverging and n colour gradients (i.e., \code{\link[ggplot2:scale_gradient]{scale_colour_gradient2()}},
+\code{\link[ggplot2:scale_gradient]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
 scales, which always use \code{\link[scales:rescale]{scales::rescale()}}.}
     \item{\code{oob}}{One of:
 \itemize{
 \item Function that handles limits outside of the scale limits
 (out of bounds).
-\item The default (\code{\link[scales:censor]{scales::censor()}}) replaces out of
+\item The default (\code{\link[scales:oob]{scales::censor()}}) replaces out of
 bounds values with \code{NA}.
-\item \code{\link[scales:squish]{scales::squish()}} for squishing out of bounds values into range.
-\item \code{\link[scales:squish_infinite]{scales::squish_infinite()}} for squishing infinite values into range.
+\item \code{\link[scales:oob]{scales::squish()}} for squishing out of bounds values into range.
+\item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
 }}
     \item{\code{trans}}{For continuous scales, the name of a transformation object
 or the object itself. Built-in transformations include "asn", "atanh",

--- a/man/variance.Rd
+++ b/man/variance.Rd
@@ -13,7 +13,7 @@ variance(x, ...)
 }
 \description{
 A generic function for computing the variance of an object. The default
-method will use \code{\link[stats:var]{stats::var()}} to compute the variance.
+method will use \code{\link[stats:cor]{stats::var()}} to compute the variance.
 }
 \seealso{
 \code{\link[=variance.distribution]{variance.distribution()}}

--- a/tests/testthat/test-dist-student-t.R
+++ b/tests/testthat/test-dist-student-t.R
@@ -22,3 +22,28 @@ test_that("Student T distribution", {
   expect_equal(mean(dist), 0)
   expect_equal(variance(dist), 5 / (5-2))
 })
+
+test_that("Noncentral Student t distribution", {
+  dist <- dist_student_t(8, ncp = 6)
+
+  expect_equal(format(dist), "t(8)")
+
+  # quantiles
+  expect_equal(quantile(dist, 0.1), stats::qt(0.1, 8, ncp = 6))
+  expect_equal(quantile(dist, 0.5), stats::qt(0.5, 8, ncp = 6))
+
+  # pdf
+  expect_equal(density(dist, 0), stats::dt(0, 8, ncp = 6))
+  expect_equal(density(dist, 3), stats::dt(3, 8, ncp = 6))
+
+  # cdf
+  expect_equal(cdf(dist, 0), stats::pt(0, 8, ncp = 6))
+  expect_equal(cdf(dist, 3), stats::pt(3, 8, ncp = 6))
+
+  # F(Finv(a)) ~= a
+  expect_equal(cdf(dist, quantile(dist, 0.4246)), 0.4246, tolerance = 1e-3)
+
+  # stats
+  expect_equal(mean(dist), 2 * gamma(7/2))
+  expect_equal(variance(dist), 148/3 - 4 * gamma(7/2)^2)
+})

--- a/tests/testthat/test-dist-student-t.R
+++ b/tests/testthat/test-dist-student-t.R
@@ -47,3 +47,53 @@ test_that("Noncentral Student t distribution", {
   expect_equal(mean(dist), 2 * gamma(7/2))
   expect_equal(variance(dist), 148/3 - 4 * gamma(7/2)^2)
 })
+
+test_that("Location-scale Student t distribution", {
+  dist <- dist_student_t(5, 2, 3)
+
+  expect_equal(format(dist), "t(5, 2, 3)")
+
+  # quantiles
+  expect_equal(quantile(dist, 0.1), stats::qt(0.1, 5)*3 + 2)
+  expect_equal(quantile(dist, 0.5), stats::qt(0.5, 5)*3 + 2)
+
+  # pdf
+  expect_equal(density(dist, 0), stats::dt(-2/3, 5)/3)
+  expect_equal(density(dist, 3), stats::dt((3-2)/3, 5)/3)
+
+  # cdf
+  expect_equal(cdf(dist, 0), stats::pt(-2/3, 5))
+  expect_equal(cdf(dist, 3), stats::pt((3-2)/3, 5))
+
+  # F(Finv(a)) ~= a
+  expect_equal(cdf(dist, quantile(dist, 0.4246)), 0.4246, tolerance = 1e-3)
+
+  # stats
+  expect_equal(mean(dist), 2)
+  expect_equal(variance(dist), 5 / (5-2) * 3^2)
+})
+
+test_that("Noncentral location-scale Student t distribution", {
+  dist <- dist_student_t(5, 2, 3, ncp = 6)
+
+  expect_equal(format(dist), "t(5, 2, 3, 6)")
+
+  # quantiles
+  expect_equal(quantile(dist, 0.1), stats::qt(0.1, 5, 6)*3 + 2)
+  expect_equal(quantile(dist, 0.5), stats::qt(0.5, 5, 6)*3 + 2)
+
+  # pdf
+  expect_equal(density(dist, 0), stats::dt(-2/3, 5, 6)/3)
+  expect_equal(density(dist, 3), stats::dt((3-2)/3, 5, 6)/3)
+
+  # cdf
+  expect_equal(cdf(dist, 0), stats::pt(-2/3, 5, 6))
+  expect_equal(cdf(dist, 3), stats::pt((3-2)/3, 5, 6))
+
+  # F(Finv(a)) ~= a
+  expect_equal(cdf(dist, quantile(dist, 0.4246)), 0.4246, tolerance = 1e-3)
+
+  # stats
+  expect_equal(mean(dist), 2 + 6 * sqrt(5/2) * gamma(2)/gamma(5/2) * 3)
+  expect_equal(variance(dist), ((5*(1+6^2))/(5-2) - (6 * sqrt(5/2) * (gamma((5-1)/2)/gamma(5/2)))^2)*3^2)
+})

--- a/tests/testthat/test-dist-student-t.R
+++ b/tests/testthat/test-dist-student-t.R
@@ -1,7 +1,7 @@
 test_that("Student T distribution", {
   dist <- dist_student_t(5)
 
-  expect_equal(format(dist), "t(5)")
+  expect_equal(format(dist), "t(5, 0, 1)")
 
   # quantiles
   expect_equal(quantile(dist, 0.1), stats::qt(0.1, 5))
@@ -26,7 +26,7 @@ test_that("Student T distribution", {
 test_that("Noncentral Student t distribution", {
   dist <- dist_student_t(8, ncp = 6)
 
-  expect_equal(format(dist), "t(8)")
+  expect_equal(format(dist), "t(8, 0, 1, 6)")
 
   # quantiles
   expect_equal(quantile(dist, 0.1), stats::qt(0.1, 8, ncp = 6))


### PR DESCRIPTION
This PR converts `dist_student_t` to location-scale form. It closes #28.

Specific changes:

- Changes the constructor signature from `dist_student_t(df, ncp = NULL)` to `dist_student_t(df, mu = 0, sigma = 1, ncp = NULL)`
- Converts the cdf, quantile, density, generate, mean, and variance functions to location-scale form
- Adds tests for the noncentral t, location-scale t, and noncentral location-scale t distributions. Not sure anyone ever uses that last combination, but it seemed simpler to allow it than to add a special-case to disallow it :).
- Change the printing format for the t distribution to be `t(df, mu, sigma)` when `ncp` is `NULL` and `t(df, mu, sigma, ncp)` when `ncp` is not `NULL`. I'm not sure if that's what you'd like but it was the best option I could think of. Let me know if you'd rather something else.