### PR TITLE
dist_degenerate: add support for multiple values

### DIFF
--- a/R/dist_degenerate.R
+++ b/R/dist_degenerate.R
@@ -75,17 +75,17 @@ format.dist_degenerate <- function(x, ...){
 
 #' @export
 density.dist_degenerate <- function(x, at, ...){
-  if(at == x[["x"]]) 1 else 0
+  ifelse(at == x[["x"]], 1, 0)
 }
 
 #' @export
 quantile.dist_degenerate <- function(x, p, ...){
-  x[["x"]]
+  ifelse(p < 0 | p > 1, NaN, x[["x"]])
 }
 
 #' @export
 cdf.dist_degenerate <- function(x, q, ...){
-  if(q >= x[["x"]]) 1 else 0
+  ifelse(q >= x[["x"]], 1, 0)
 }
 
 #' @export


### PR DESCRIPTION
Hello Mitchell,

as far as I can see all distributions except `dist_degenerate()` support evaluation of multiple values for a single distribution, for example:

```r
density(dist_normal()[[1]], 1:5)
```

In addition, returning `NaN` when calling `quantile()`  with values outside of `[0, 1]` would be more consistent as well. 

Best regards
David
