### PR TITLE
Automatically supply inverses of known functions

### DIFF
--- a/R/default.R
+++ b/R/default.R
@@ -220,7 +220,7 @@ get_binary_inverse_2 <- function(f, constant) {
     `+` = function(x) x - constant,
     `-` = function(x) constant - x,
     `*` = function(x) x / constant,
-    `/` = function(x) x * constant,
+    `/` = function(x) constant / x,
     `^` = function(x) log(x, base = constant),
 
     invert_fail

--- a/R/default.R
+++ b/R/default.R
@@ -158,7 +158,6 @@ dim.dist_default <- function(x){
 }
 
 invert_fail <- function(...) stop("Inverting transformations for distributions is not yet supported.")
-
 inverse_functions <- exprs(
   sqrt = function(x) x^2,
   exp = log,
@@ -180,6 +179,13 @@ inverse_functions <- exprs(
   asinh = sinh,
   atanh = tanh
 )
+#' Attempt to get the inverse of a known function by name. Returns invert_fail
+#' (a function that raises an error if called) if there is no known inverse.
+#' @param f string. Name of a function.
+#' @noRd
+get_inverse_function <- function(f) {
+  inverse_functions[[f]] %||% invert_fail
+}
 
 #' @method Math dist_default
 #' @export
@@ -188,7 +194,7 @@ Math.dist_default <- function(x, ...) {
 
   trans <- new_function(exprs(x = ), body = expr((!!sym(.Generic))(x, !!!dots_list(...))))
 
-  inverse_fun <- inverse_functions[[.Generic]] %||% invert_fail
+  inverse_fun <- get_inverse_function(.Generic)
   inverse <- new_function(exprs(x = ), body = expr((!!inverse_fun)(x, !!!dots_list(...))))
 
   vec_data(dist_transformed(wrap_dist(list(x)), trans, inverse))[[1]]

--- a/R/default.R
+++ b/R/default.R
@@ -159,12 +159,39 @@ dim.dist_default <- function(x){
 
 invert_fail <- function(...) stop("Inverting transformations for distributions is not yet supported.")
 
+inverse_functions <- exprs(
+  sqrt = function(x) x^2,
+  exp = log,
+  log = function(x, base = exp(1)) base ^ x,
+  log2 = function(x) 2^x,
+  log10 = function(x) 10^x,
+  expm1 = log1p,
+  log1p = expm1,
+  cos = acos,
+  sin = asin,
+  tan = atan,
+  acos = cos,
+  asin = sin,
+  atan = tan,
+  cosh = acosh,
+  sinh = asinh,
+  tanh = atanh,
+  acosh = cosh,
+  asinh = sinh,
+  atanh = tanh
+)
+
 #' @method Math dist_default
 #' @export
 Math.dist_default <- function(x, ...) {
   if(dim(x) > 1) stop("Transformations of multivariate distributions are not yet supported.")
+
   trans <- new_function(exprs(x = ), body = expr((!!sym(.Generic))(x, !!!dots_list(...))))
-  vec_data(dist_transformed(wrap_dist(list(x)), trans, invert_fail))[[1]]
+
+  inverse_fun <- inverse_functions[[.Generic]] %||% invert_fail
+  inverse <- new_function(exprs(x = ), body = expr((!!inverse_fun)(x, !!!dots_list(...))))
+
+  vec_data(dist_transformed(wrap_dist(list(x)), trans, inverse))[[1]]
 }
 
 #' @method Ops dist_default

--- a/R/dist_lognormal.R
+++ b/R/dist_lognormal.R
@@ -145,10 +145,21 @@ kurtosis.dist_lognormal <- function(x, ...) {
   exp(4*s2) + 2*exp(3*s2) + 3*exp(2*s2) - 6
 }
 
+# make a normal distribution from a lognormal distribution using the
+# specified base
+normal_dist_with_base <- function(x, base = exp(1)) {
+  vec_data(dist_normal(x[["mu"]], x[["sigma"]]) / log(base))[[1]]
+}
+
 #' @method Math dist_lognormal
 #' @export
 Math.dist_lognormal <- function(x, ...) {
-  # Shortcut to get Normal distribution from log-normal.
-  if(.Generic == "log") return(vec_data(dist_normal(x[["mu"]], x[["sigma"]]))[[1]])
-  NextMethod()
+  switch(.Generic,
+    # Shortcuts to get Normal distribution from log-normal.
+    log = normal_dist_with_base(x, ...),
+    log2 = normal_dist_with_base(x, 2),
+    log10 = normal_dist_with_base(x, 10),
+
+    NextMethod()
+  )
 }

--- a/R/hilo.R
+++ b/R/hilo.R
@@ -109,7 +109,6 @@ vec_math.hilo <- function(.fn, .x, ...){
   vec_restore(out, .x)
 }
 
-#' @rdname vctrs-compat
 #' @method vec_arith hilo
 #' @export
 vec_arith.hilo <- function(op, x, y, ...){

--- a/R/plot.R
+++ b/R/plot.R
@@ -10,7 +10,7 @@
 #' @param x The distribution(s) to plot.
 #' @param ... Unused.
 #'
-#' @keyword internal
+#' @keywords internal
 #'
 #' @export
 autoplot.distribution <- function(x, ...){

--- a/R/transformed.R
+++ b/R/transformed.R
@@ -38,7 +38,7 @@ format.dist_transformed <- function(x, ...){
 
 #' @export
 density.dist_transformed <- function(x, at, ...){
-  density(x[["dist"]], x[["inverse"]](at))*vapply(at, numDeriv::jacobian, numeric(1L), func = x[["inverse"]])
+  density(x[["dist"]], x[["inverse"]](at))*abs(vapply(at, numDeriv::jacobian, numeric(1L), func = x[["inverse"]]))
 }
 
 #' @export

--- a/R/transformed.R
+++ b/R/transformed.R
@@ -83,7 +83,11 @@ covariance.dist_transformed <- function(x, ...){
 #' @export
 Math.dist_transformed <- function(x, ...) {
   trans <- new_function(exprs(x = ), body = expr((!!sym(.Generic))((!!x$transform)(x), !!!dots_list(...))))
-  vec_data(dist_transformed(wrap_dist(list(x[["dist"]])), trans, invert_fail))[[1]]
+
+  inverse_fun <- get_inverse_function(.Generic)
+  inverse <- new_function(exprs(x = ), body = expr((!!x$inverse)((!!inverse_fun)(x, !!!dots_list(...)))))
+
+  vec_data(dist_transformed(wrap_dist(list(x[["dist"]])), trans, inverse))[[1]]
 }
 
 #' @method Ops dist_transformed

--- a/R/transformed.R
+++ b/R/transformed.R
@@ -84,7 +84,7 @@ covariance.dist_transformed <- function(x, ...){
 Math.dist_transformed <- function(x, ...) {
   trans <- new_function(exprs(x = ), body = expr((!!sym(.Generic))((!!x$transform)(x), !!!dots_list(...))))
 
-  inverse_fun <- get_inverse_function(.Generic)
+  inverse_fun <- get_unary_inverse(.Generic)
   inverse <- new_function(exprs(x = ), body = expr((!!x$inverse)((!!inverse_fun)(x, !!!dots_list(...)))))
 
   vec_data(dist_transformed(wrap_dist(list(x[["dist"]])), trans, inverse))[[1]]
@@ -105,5 +105,16 @@ Ops.dist_transformed <- function(e1, e2) {
   } else {
     new_function(exprs(x = ), body = expr((!!sym(.Generic))(!!e1, (!!e2$transform)(x))))
   }
-  vec_data(dist_transformed(wrap_dist(list(list(e1,e2)[[which(is_dist)[1]]][["dist"]])), trans, invert_fail))[[1]]
+
+  inverse <- if(all(is_dist)) {
+    invert_fail
+  } else if(is_dist[1]){
+    inverse_fun <- get_binary_inverse_1(.Generic, e2)
+    new_function(exprs(x = ), body = expr((!!e1$inverse)((!!inverse_fun)(x))))
+  } else {
+    inverse_fun <- get_binary_inverse_2(.Generic, e1)
+    new_function(exprs(x = ), body = expr((!!e2$inverse)((!!inverse_fun)(x))))
+  }
+
+  vec_data(dist_transformed(wrap_dist(list(list(e1,e2)[[which(is_dist)[1]]][["dist"]])), trans, inverse))[[1]]
 }

--- a/man/autoplot.distribution.Rd
+++ b/man/autoplot.distribution.Rd
@@ -20,3 +20,4 @@ the {ggdist} package to produce your own distribution plots. You can learn
 more about how this plot can be produced using {ggdist} here:
 https://mjskay.github.io/ggdist/articles/slabinterval.html
 }
+\keyword{internal}

--- a/tests/testthat/test-transformations.R
+++ b/tests/testthat/test-transformations.R
@@ -43,6 +43,11 @@ test_that("LogNormal distributions", {
     dist_normal(0, 0.5)
   )
 
+  # Test log() shortcut with different bases
+  expect_equal(log(dist_lognormal(0, log(3)), base = 3), dist_normal(0, 1))
+  expect_equal(log2(dist_lognormal(0, log(2))), dist_normal(0, 1))
+  expect_equal(log10(dist_lognormal(0, log(10))), dist_normal(0, 1))
+
   # format
   expect_equal(format(dist), sprintf("t(%s)", format(dist_normal(0, 0.5))))
 
@@ -70,4 +75,42 @@ test_that("LogNormal distributions", {
   # stats (approximate due to bias adjustment method)
   expect_equal(mean(dist), exp(0.25/2), tolerance = 0.01)
   expect_equal(variance(dist), (exp(0.25) - 1)*exp(0.25), tolerance = 0.1)
+})
+
+test_that("inverses are applied automatically", {
+  dist <- dist_gamma(1,1)
+  log2dist <- log(dist, base = 2)
+  log2dist_t <- dist_transformed(dist, log2, function(x) 2 ^ x)
+
+  expect_equal(density(log2dist, 0.5), density(log2dist_t, 0.5))
+  expect_equal(cdf(log2dist, 0.5), cdf(log2dist_t, 0.5))
+  expect_equal(quantile(log2dist, 0.5), quantile(log2dist_t, 0.5))
+
+  # test multiple transformations that get stacked together by dist_transformed
+  explogdist <- exp(log(dist))
+  expect_equal(density(dist, 0.5), density(explogdist, 0.5))
+  expect_equal(cdf(dist, 0.5), cdf(explogdist, 0.5))
+  expect_equal(quantile(dist, 0.5), quantile(explogdist, 0.5))
+
+  # test multiple transformations created by operators (via Ops)
+  explog2dist <- 2 ^ log2dist
+  expect_equal(density(dist, 0.5), density(explog2dist, 0.5))
+  expect_equal(cdf(dist, 0.5), cdf(explog2dist, 0.5))
+  expect_equal(quantile(dist, 0.5), quantile(explog2dist, 0.5))
+
+  # basic set of inverses
+  expect_equal(density(sqrt(dist^2), 0.5), density(dist, 0.5))
+  expect_equal(density(exp(log(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(10^(log10(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(expm1(log1p(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(cos(acos(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(sin(asin(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(tan(atan(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(cosh(acosh(dist + 1)) - 1, 0.5), density(dist, 0.5))
+  expect_equal(density(sinh(asinh(dist)), 0.5), density(dist, 0.5))
+  expect_equal(density(tanh(atanh(dist)), 0.5), density(dist, 0.5))
+
+  expect_equal(density(dist + 1 - 1, 0.5), density(dist, 0.5))
+  expect_equal(density(dist * 2 / 2, 0.5), density(dist, 0.5))
+
 })

--- a/tests/testthat/test-transformations.R
+++ b/tests/testthat/test-transformations.R
@@ -113,4 +113,8 @@ test_that("inverses are applied automatically", {
   expect_equal(density(dist + 1 - 1, 0.5), density(dist, 0.5))
   expect_equal(density(dist * 2 / 2, 0.5), density(dist, 0.5))
 
+  # inverting a gamma distribution
+  expect_equal(density(1/dist_gamma(4, 3), 0.5), density(dist_inverse_gamma(4, 1/3), 0.5))
+  expect_equal(density(1/(1/dist_gamma(4, 3)), 0.5), density(dist_gamma(4, 3), 0.5))
+
 })


### PR DESCRIPTION
Hi --- as I've been mocking up more examples and use cases for {distributional} with {ggdist} one of the things that I kept running into was the error `Inverting transformations for distributions is not yet supported`, usually when transforming a distribution and then trying to visualize it. This is because visualizing distributions with ggdist typically requires all of `cdf()`, `quantile()`, and `density()` to be defined, and these do not all work without knowing the inverse transformation.

While I figured out I could use `dist_transformed()` directly to work around this (e.g. by replacing things like `log2(dist_XXX())` with `dist_transformed(dist_XXX(), log2, function(x) 2^x)`, this seemed awkward, since we have several known elementary functions with inverses handled by the `Math` and `Ops` generics. So, this pull request modifies those generics to automatically supply inverses for several functions.

This allows you to visualize pretty arbitrary chains of transformations without manually specifying the inverse. A very silly example (this uses the `unify-dist` branch of ggdist; i.e. `install_github("mjskay/ggdist@unify-dist")`):

```r
data.frame(
  y = 1:5,
  x = (log(dist_gamma(1,1)) / 2 + 4) * 1:5
) %>%
  ggplot(aes(y = y, xdist = x)) +
  stat_halfeye()
```
![image](https://user-images.githubusercontent.com/6345019/147535497-3ebb30ae-1329-4211-a9f5-a8c4ea0b40b9.png)

Let me know if this seems reasonable. Happy to take feedback and adjust as needed.