### PR TITLE
Minor fixes to `quantile(<dist_mixture>)` and `cdf(<dist_sample>)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Fixed object structure resulting from transforming sample distributions (#81).
 * Improved reliability of `quantile(<dist_mixture>)`.
+* Defined `cdf(<dist_sample>)` as Pr(X <= x), not Pr(X < x).
 
 # distributional 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Fixed object structure resulting from transforming sample distributions (#81).
+* Improved reliability of `quantile(<dist_mixture>)`.
 
 # distributional 0.3.1
 

--- a/R/dist_sample.R
+++ b/R/dist_sample.R
@@ -89,7 +89,7 @@ cdf.dist_sample <- function(x, q, ..., na.rm = TRUE){
     )
   }
   if(length(q) > 1) return(vapply(q, cdf, numeric(1L), x = x, ...))
-  vapply(x, function(x, q) mean(x < q, ..., na.rm = na.rm), numeric(1L), q = q)
+  vapply(x, function(x, q) mean(x <= q, ..., na.rm = na.rm), numeric(1L), q = q)
 }
 
 #' @export

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -52,10 +52,11 @@ quantile.dist_mixture <- function(x, p, ...){
   if(p == 1) return(max(dist_q))
 
   # Search the cdf() for appropriate quantile
-  stats::optimise(
-    function(pos) (p - cdf(x, pos, ...))^2,
-    interval = c(min(dist_q), max(dist_q))
-  )$minimum
+  stats::uniroot(
+    function(pos) p - cdf(x, pos, ...),
+    interval = c(min(dist_q), max(dist_q)),
+    extendInt = "yes"
+  )$root
 }
 
 #' @export

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -30,7 +30,7 @@ dist_mixture <- function(..., weights = numeric()){
 format.dist_mixture <- function(x, ...){
   sprintf(
     "mixture(n=%i)",
-    length(x)
+    length(x[["dist"]])
   )
 }
 

--- a/tests/testthat/test-dist-mixture.R
+++ b/tests/testthat/test-dist-mixture.R
@@ -1,8 +1,0 @@
-test_that("quantile(<dist_mixture>)", {
-  x <- dist_mixture(dist_degenerate(1), dist_degenerate(2), dist_degenerate(3), weights = c(0.1, 0.2, 0.7))
-
-  expect_equal(mean(x), 2.6)
-  expect_equal(density(x, 1:3)[[1]], c(0.1, 0.2, 0.7))
-  expect_equal(cdf(x, 1:3)[[1]], c(0.1, 0.3, 1))
-  expect_equal(quantile(x, c(0, 0.1, 0.3, 1))[[1]], c(1, 1:3), tolerance = .Machine$double.eps^0.25)
-})

--- a/tests/testthat/test-dist-mixture.R
+++ b/tests/testthat/test-dist-mixture.R
@@ -1,0 +1,8 @@
+test_that("quantile(<dist_mixture>)", {
+  x <- dist_mixture(dist_degenerate(1), dist_degenerate(2), dist_degenerate(3), weights = c(0.1, 0.2, 0.7))
+
+  expect_equal(mean(x), 2.6)
+  expect_equal(density(x, 1:3)[[1]], c(0.1, 0.2, 0.7))
+  expect_equal(cdf(x, 1:3)[[1]], c(0.1, 0.3, 1))
+  expect_equal(quantile(x, c(0, 0.1, 0.3, 1))[[1]], c(1, 1:3), tolerance = .Machine$double.eps^0.25)
+})

--- a/tests/testthat/test-dist-sample.R
+++ b/tests/testthat/test-dist-sample.R
@@ -26,3 +26,7 @@ test_that("Emperical/sample distribution", {
     dist + 1 - 1
   )
 })
+
+test_that("CDF of degenerate dist_sample() is correct", {
+  expect_equal(cdf(dist_sample(list(2)), 2)[[1]], 1)
+})

--- a/tests/testthat/test-mixture.R
+++ b/tests/testthat/test-mixture.R
@@ -47,3 +47,22 @@ test_that("Mixture of different distributions", {
   expect_equal(mean(dist), 0)
   expect_equal(variance(dist), 1.175)
 })
+
+test_that("Mixture of point masses", {
+  dist <- dist_mixture(dist_degenerate(1), dist_degenerate(2), dist_degenerate(3), weights = c(0.1, 0.2, 0.7))
+
+  # format
+  expect_equal(format(dist), "mixture(n=3)")
+
+  # quantiles
+  expect_equal(quantile(dist, c(0, 0.1, 0.3, 1))[[1]], c(1, 1:3), tolerance = .Machine$double.eps^0.25)
+
+  # pmf
+  expect_equal(density(dist, 1:3)[[1]], c(0.1, 0.2, 0.7))
+
+  #cdf
+  expect_equal(cdf(dist, 1:3)[[1]], c(0.1, 0.3, 1))
+
+  #mean
+  expect_equal(mean(dist), 2.6)
+})


### PR DESCRIPTION
Two minor bugfixes for some issues I ran into when trying to improve support for visualizing discrete distributions in {ggdist}:

- `quantile(<dist_mixture>)` gives weird results on discrete mixtures. For example, on `master`:

```r
x <- dist_mixture(dist_degenerate(1), dist_degenerate(2), dist_degenerate(3), weights = c(0.1, 0.2, 0.7))
quantile(x, c(0, 0.1, 0.3, 1))[[1]]
#> [[1]]
#> [1] 1.000000 1.472202 2.236134 3.000000
```

This should be `1 1 2 3`. This PR changes the implementation of `quantile.dist_mixture()` to use `uniroot()` instead of `optimise()`, which seems to fix the problem (at least, to within the default tolerance of `.Machine$double.eps^0.25`):

```r
quantile(x, c(0, 0.1, 0.3, 1))
#> [[1]]
#> [1] 1.000000 1.000000 2.000034 3.000000
```

* `cdf(<dist_sample>)` is currently defined as $P(X < x)$ rather than $P(X \le x)$. I believe it should be the latter (which would also be consistent with `ecdf()`). For example, on `master`:

```r
cdf(dist_sample(list(2)), 2)
#> x 
#> 0 
```

This should be `1`. This PR changes the implementation of `cdf.dist_sample()` accordingly:

```r
cdf(dist_sample(list(2)), 2)
#> x 
#> 1
```

Tests are included for both fixes. There is also a minor fix to `format(<dist_mixture>)`, though it didn't seem newsworthy to me.