### PR TITLE
fix density(<dist_categorical>, x) for x <= 0

### DIFF
--- a/R/dist_categorical.R
+++ b/R/dist_categorical.R
@@ -93,6 +93,7 @@ format.dist_categorical <- function(x, digits = 2, ...){
 #' @export
 density.dist_categorical <- function(x, at, ...){
   if(!is.null(x[["x"]])) at <- match(at, x[["x"]])
+  at[at <= 0] <- NA
   x[["p"]][at]
 }
 

--- a/tests/testthat/test-dist_categorical.R
+++ b/tests/testthat/test-dist_categorical.R
@@ -8,8 +8,11 @@ test_that("Categorical distribution", {
   expect_true(all(is.na(quantile(dist, 0.2))))
 
   # pdf
+  expect_equal(density(dist, -1), NA_real_)
+  expect_equal(density(dist, 0), NA_real_)
   expect_equal(density(dist, 1), 0.4)
   expect_equal(density(dist, 2), 0.2)
+  expect_equal(density(dist, 5), NA_real_)
 
   # cdf
   expect_true(all(is.na(cdf(dist, 1))))


### PR DESCRIPTION
Another minor bugfix on categorical dists. Probably not worthy of a news item (but I can write one if you'd like).

Basically, there's some weird behavior in `density.dist_categorical()` due to R's indexing rules when `i <= 0`:

```r
> density(dist_categorical(list(1:3)), -1)
[1] 0.3333333 0.5000000
> density(dist_categorical(list(1:3)), 0)
numeric(0)
```

With the fix:

```r
> density(dist_categorical(list(1:3)), -1)
[1] NA
> density(dist_categorical(list(1:3)), 0)
[1] NA
```