### PR TITLE
Allow unary negation to work with all distributions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # distributional (development version)
 
+## Bug fixes
+
+* Fixed error when using '-' as a unary operator on a distribution different from
+ `dist_normal()` by @venpopov (#95)
+
 # distributional 0.4.0
 
 ## Breaking changes

--- a/R/default.R
+++ b/R/default.R
@@ -266,6 +266,11 @@ Math.dist_default <- function(x, ...) {
 #' @method Ops dist_default
 #' @export
 Ops.dist_default <- function(e1, e2) {
+  if(.Generic %in% c("-", "+") && missing(e2)){
+    e2 <- e1
+    e1 <- if(.Generic == "+") 1 else -1
+    .Generic <- "*"
+  }
   is_dist <- c(inherits(e1, "dist_default"), inherits(e2, "dist_default"))
   if(any(vapply(list(e1, e2)[is_dist], dim, numeric(1L)) > 1)){
     stop("Transformations of multivariate distributions are not yet supported.")

--- a/R/transformed.R
+++ b/R/transformed.R
@@ -94,6 +94,11 @@ Math.dist_transformed <- function(x, ...) {
 #' @method Ops dist_transformed
 #' @export
 Ops.dist_transformed <- function(e1, e2) {
+  if(.Generic %in% c("-", "+") && missing(e2)){
+    e2 <- e1
+    e1 <- if(.Generic == "+") 1 else -1
+    .Generic <- "*"
+  }
   is_dist <- c(inherits(e1, "dist_default"), inherits(e2, "dist_default"))
   trans <- if(all(is_dist)) {
     if(identical(e1$dist, e2$dist)){

--- a/tests/testthat/test-transformations.R
+++ b/tests/testthat/test-transformations.R
@@ -118,3 +118,14 @@ test_that("inverses are applied automatically", {
   expect_equal(density(1/(1/dist_gamma(4, 3)), 0.5), density(dist_gamma(4, 3), 0.5))
 
 })
+
+test_that("unary negation operator works", {
+  dist <- dist_normal(1,1)
+  expect_equal(density(-dist, 0.5), density(dist, -0.5))
+
+  dist <- dist_wrap('norm', mean = 1)
+  expect_equal(density(-dist, 0.5), density(dist, -0.5))
+
+  dist <- dist_student_t(3, mu = 1)
+  expect_equal(density(-dist, 0.5), density(dist, -0.5))
+})


### PR DESCRIPTION
## Summary

Fixed #95. I added a test showing that `-dist_wrap('norm')` and `-dist_student_t(3)` fail before the fix and pass afterwards.

Not sure if this is the optimal approach, but I just copy pasted the part from `Ops.dist_normal` that handled the unary negation to the code for `Ops.dist_default` and `Ops.dist_transformed`