### PR TITLE
Fix floating point issue with weights

### DIFF
--- a/R/mixture.R
+++ b/R/mixture.R
@@ -16,7 +16,7 @@ dist_mixture <- function(..., weights = numeric()){
   dn <- if(length(dn) == 1) dn[[1]] else NULL
 
   vec_is(weights, numeric(), length(dist))
-  if(sum(weights) != 1){
+  if(!all.equal(sum(weights),1)){
     abort("Weights of a mixture model must sum to 1.")
   }
   if(any(weights < 0)){


### PR DESCRIPTION
This is to resolves issue #134 I put in one Friday. Basically, the issue I was running into was valid mixture distributions were failing because the two floats summed together to 1 with small floating point error. This would trigger the not summing to 1 error. 