### PR TITLE
Force double storage to avoid overflow

### DIFF
--- a/R/dist_hypergeometric.R
+++ b/R/dist_hypergeometric.R
@@ -153,7 +153,7 @@ skewness.dist_hypergeometric <- function(x, ...) {
   n <- x[["k"]]
 
   a <- (N - 2 * K) * (N - 1)^0.5 * (N - 2 * n)
-  b <- (n * K * (N - K) * (N - n))^0.5 * (N - 2)
+  b <- (1 * n * K * (N - K) * (N - n))^0.5 * (N - 2)
   a / b
 }
 
@@ -163,5 +163,5 @@ kurtosis.dist_hypergeometric <- function(x, ...) {
   K <- x[["m"]]
   n <- x[["k"]]
 
-  1 / (n * K * (N - K) * (N - n) * (N - 2) * (N - 3))
+  1 / (1 * n * K * (N - K) * (N - n) * (N - 2) * (N - 3))
 }


### PR DESCRIPTION
Currently, these terms might overflow and throw a warning, as they do in some package examples.

R does not back up to `double` when finding overflow, see `2L * .Machine$integer.max`.